### PR TITLE
Angi devel+fatal conditions

### DIFF
--- a/SAPHanaSR-tester.spec
+++ b/SAPHanaSR-tester.spec
@@ -20,8 +20,8 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Test suite for SAPHanaSR clusters
-Version:        1.2.99
-Release:        0-beta
+Version:        1.3.0
+Release:        0
 Url:            https://www.suse.com/c/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution/
 
 BuildArch:      noarch

--- a/SAPHanaSR-tester.spec
+++ b/SAPHanaSR-tester.spec
@@ -20,8 +20,8 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Test suite for SAPHanaSR clusters
-Version:        1.2.14
-Release:        0
+Version:        1.2.99
+Release:        0-beta
 Url:            https://www.suse.com/c/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution/
 
 BuildArch:      noarch

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -9,3 +9,4 @@ python_examples
 tmux
 testLog*.txt
 .test_properties
+*.backup.*

--- a/test/json/angi-ScaleOut/fatal1.json
+++ b/test/json/angi-ScaleOut/fatal1.json
@@ -1,0 +1,63 @@
+{
+    "test": "flop",
+    "name": "flop - this test should NOT pass successfully",
+    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester" ],
+    "start": "prereq10",
+    "steps": [
+        {
+            "step": "prereq10",
+            "name": "test prerequitsites",
+            "next": "final40",
+            "loop": 1,
+            "wait": 1,
+            "post": "sleep 4",
+            "pSite": [
+                "lpt >~ 2000000000:^(20|30|1.........)$",
+                "lss == 4",
+                "srr == P",
+                "srHook == PRIM",
+                "srPoll == PRIM"
+            ],
+            "sSite": "sSiteUp",
+            "pHost": "pHostUp",
+            "sHost": "sHostUp",
+	        "pWorker": "pWorkerUp",
+            "sWorker": "sWorkerUp",
+            "fatalCondition": {
+                        "comment": "fata01 (all conditons) OR fatal02 (all conditions) OR fatal_dual_P (all conditions)",
+                        "next":    "end",
+                        "fatal01" : {
+                                        "pHost": [
+                                                    "score is None",
+                                                    "roles is None"
+                                                ]
+                                    },
+                        "fatal02" : {
+                                        "sHost": [
+                                                    "score is None",
+                                                    "roles is None"
+                                                ]
+                                    },
+                        "fatal_dual_P" : {
+                                        "pSite": [ "lss == 4", "srr == P" ],
+                                        "sSite": [ "lss == 4", "srr == P" ]
+                                    }
+                    }
+        },
+        {
+            "step": "final40",
+            "name": "still running",
+            "next": "END",
+            "loop": 1,
+            "wait": 1,
+            "pSite": [
+                "lpt is None"
+            ],
+            "sSite": "sSiteUp",
+            "pHost": "pHostUp",
+            "sHost": "sHostUp",
+	    "pWorker": "pWorkerUp",
+            "sWorker": "sWorkerUp"
+        }
+    ]
+}

--- a/test/json/angi-ScaleOut/fatal1.json
+++ b/test/json/angi-ScaleOut/fatal1.json
@@ -1,7 +1,7 @@
 {
-    "test": "flop",
-    "name": "flop - this test should NOT pass successfully",
-    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester" ],
+    "test": "fatal1",
+    "name": "fatal1 - example for fatalConditions",
+    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester", "fatal" ],
     "start": "prereq10",
     "steps": [
         {

--- a/test/json/angi-ScaleOut/fatal2.json
+++ b/test/json/angi-ScaleOut/fatal2.json
@@ -1,0 +1,66 @@
+{
+    "test": "flop",
+    "name": "flop - this test should NOT pass successfully",
+    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester" ],
+    "start": "prereq10",
+    "steps": [
+        {
+            "step": "prereq10",
+            "name": "test prerequitsites",
+            "next": "final40",
+            "loop": 1,
+            "wait": 1,
+            "post": "sleep 4",
+            "pSite": [
+                "lpt >~ 2000000000:^(20|30|1.........)$",
+                "lss == 4",
+                "srr == P",
+                "srHook == PRIM",
+                "srPoll == PRIM"
+            ],
+            "sSite": "sSiteUp",
+            "pHost": "pHostUp",
+            "sHost": "sHostUp",
+	        "pWorker": "pWorkerUp",
+            "sWorker": "sWorkerUp",
+            "fatalCondition": {
+                        "comment": "fata01 (all conditons) OR fatal02 (all conditions) OR fatal_dual_P (all conditions)",
+                        "next":    "end",
+                        "false_fatal_P" : {
+                                        "pSite": [ "lss == 4", "srr == P" ]
+                                    },
+                        "fatal01" : {
+                                        "pHost": [
+                                                    "score is None",
+                                                    "roles is None"
+                                                ]
+                                    },
+                        "fatal02" : {
+                                        "sHost": [
+                                                    "score is None",
+                                                    "roles is None"
+                                                ]
+                                    },
+                        "fatal_dual_P" : {
+                                        "pSite": [ "lss == 4", "srr == P" ],
+                                        "sSite": [ "lss == 4", "srr == P" ]
+                                    }
+                    }
+        },
+        {
+            "step": "final40",
+            "name": "still running",
+            "next": "END",
+            "loop": 1,
+            "wait": 1,
+            "pSite": [
+                "lpt is None"
+            ],
+            "sSite": "sSiteUp",
+            "pHost": "pHostUp",
+            "sHost": "sHostUp",
+	    "pWorker": "pWorkerUp",
+            "sWorker": "sWorkerUp"
+        }
+    ]
+}

--- a/test/json/angi-ScaleOut/fatal2.json
+++ b/test/json/angi-ScaleOut/fatal2.json
@@ -1,7 +1,7 @@
 {
-    "test": "flop",
-    "name": "flop - this test should NOT pass successfully",
-    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester" ],
+    "test": "fatal2",
+    "name": "fatal2 - this test should NOT pass successfully - fails on fatalCondition",
+    "purpose": [ "angi", "ScaleOut", "fail", "parser", "sleep", "tester", "fatal" ],
     "start": "prereq10",
     "steps": [
         {

--- a/test/tester/saphana_sr_test.py
+++ b/test/tester/saphana_sr_test.py
@@ -526,7 +526,7 @@ class SaphanasrTest:
                 #
                 if child not in ['next','comment','name']:
                     fc_child = fc[child]
-                    self.message(f"DEBUG: fatalConditions: {child} dump {fc_child}")
+                    self.debug(f"DEBUG: fatalConditions: {child} dump {fc_child}")
                     #
                     # process all check-rules ( "name": [ "condition1" {,...} ] )
                     #
@@ -536,17 +536,14 @@ class SaphanasrTest:
                         if top_obj_name in self.topo_translate:
                             area_name = self.topo_translate[top_obj_name]
                             checks = fc_child[top_obj_name]
-                            self.message(f"DEBUG: fatalConditions: area_name {area_name}, top_obj_name {top_obj_name}, obj_name {obj_name}, checks {checks}")
+                            self.debug(f"DEBUG: fatalConditions: area_name {area_name}, top_obj_name {top_obj_name}, obj_name {obj_name}, checks {checks}")
                             rc_checks = self.run_checks(checks, area_name, obj_name, step.get('step',''), fatal_check = True, fatal_name=child)
-                            self.message(f"DEBUG: fatalConditions: {child} rc {rc_checks}")
+                            self.debug(f"DEBUG: fatalConditions: {child} rc {rc_checks}")
                             rc_child = max(rc_child, rc_checks)
                 if rc_child == 0:
-                    self.message(f"DEBUG: fatalConditions: {child} BREAK")
+                    self.message(f"STATUS: fatalConditions: FAILED {child} {fc_child} - BREAK")
                     break
                 rc_condition = min(rc_condition, rc_child)
-            if rc_condition == 0:
-                if self.config['dump_failures'] and 'failed' in self.run:
-                    self.message(f"{fail_msg}: step={step_step} {self.__get_failed__()}", stdout=False)
         return rc_condition
             
 

--- a/test/tester/saphana_sr_test.py
+++ b/test/tester/saphana_sr_test.py
@@ -25,7 +25,7 @@ class SaphanasrTest:
     """
     class to check SAP HANA cluster during tests
     """
-    version = "1.2.99.0-beta"
+    version = "1.3.0"
 
     def message(self, msg, **kwargs):
         """

--- a/test/tester/saphana_sr_test.py
+++ b/test/tester/saphana_sr_test.py
@@ -32,6 +32,7 @@ class SaphanasrTest:
         message with formatted timestamp
         """
         stdout = kwargs.get('stdout', True)
+        pre_cr = kwargs.get('pre_cr', False)
         # TODO: specify, if message should be written to stdout, stderr and/or log file
         date_time = time.strftime("%Y-%m-%d %H:%M:%S")
         if self.run['r_id']:
@@ -40,6 +41,8 @@ class SaphanasrTest:
             r_id = ""
         msg_arr = msg.split(" ")
         if stdout:
+            if pre_cr:
+                print()
             print("{}{} {:<9s} {}".format(date_time, r_id, msg_arr[0], " ".join(msg_arr[1:])), flush=True)
         try:
             if self.run['log_file_handle']:
@@ -541,7 +544,7 @@ class SaphanasrTest:
                             self.debug(f"DEBUG: fatalConditions: {child} rc {rc_checks}")
                             rc_child = max(rc_child, rc_checks)
                 if rc_child == 0:
-                    self.message(f"STATUS: fatalConditions: FAILED {child} {fc_child} - BREAK")
+                    self.message(f"STATUS: fatalConditions: FAILED {child} {fc_child} - BREAK", pre_cr=True)
                     break
                 rc_condition = min(rc_condition, rc_child)
         return rc_condition
@@ -574,6 +577,7 @@ class SaphanasrTest:
                      f" max_loops='{max_loops}'"
                  )
         self.message(_l_msg)
+        fatal = False
         while loops < max_loops:
             loops = loops + 1
             if self.config['dump_failures']:
@@ -587,6 +591,7 @@ class SaphanasrTest:
                 if process_result == 0:
                     self.message("STATUS: step {} failed with fatalCondition".format(step_id))
                     process_result = 2
+                    fatal = True
                     break
             process_result = max (
                                   self.process_topology_object(step, 'global', 'Global'),
@@ -600,7 +605,7 @@ class SaphanasrTest:
             if process_result == 0:
                 break
             time.sleep(wait)
-        if self.config['dump_failures']:
+        if self.config['dump_failures'] and fatal == False:
             print("")
         self.message("STATUS: step {} checked in {} loop(s)".format(step_id, loops))
         if process_result == 0:

--- a/test/tester/saphana_sr_test.py
+++ b/test/tester/saphana_sr_test.py
@@ -583,7 +583,7 @@ class SaphanasrTest:
             if "fatalCondition" in step:
                 # self.message("STATUS: step {} to process fatalCondition".format(step_id))
                 process_result = self.process_fatal_condition(step)
-                self.message("STATUS: step {} to processed fatalCondition with process_result {}".format(step_id, process_result))
+                self.debug("DEBUG: step {} to processed fatalCondition with process_result {}".format(step_id, process_result))
                 if process_result == 0:
                     self.message("STATUS: step {} failed with fatalCondition".format(step_id))
                     process_result = 2

--- a/test/tester/saphana_sr_test.py
+++ b/test/tester/saphana_sr_test.py
@@ -511,7 +511,7 @@ class SaphanasrTest:
             rc == 0 : no fatal condition matched
             rc != 0 : at least one of the fatal packages (childs) mathed
         """
-        rc_condition = 0
+        rc_condition = 1
         fail_msg = "FATAL"
         step_step = step['step']
         if "fatalCondition" in step:


### PR DESCRIPTION
Allow test-descritions to define fatalConditions. fatal conditions must not match at any time during a test step.